### PR TITLE
Add batch_data to markdown output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ BatchSmith is a modular CLI tool for structured batch output generation using La
 - **Structured JSON validation**: Define output schemas with JSON Schema.
 - **Batch processing**: Generate multiple outputs in one run.
 - **Templated prompts**: Customize system and user prompts with template variables.
-- **Markdown conversion**: Convert the output JSON to Markdown sections (one per item) using the `--to-markdown` option, which auto-saves a `.md` file alongside the JSON output and orders fields per the schema’s `required` array.
+- **Markdown conversion**: Convert the output JSON to Markdown sections (one per item) using the `--to-markdown` option. Each section preserves the originating query and orders fields per the schema’s `required` array. A `.md` file is auto-saved alongside the JSON output.
 
 ## Requirements
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,3 +72,11 @@ def test_create_llm(monkeypatch):
         "timeout": None,
         "max_retries": 2,
     }
+
+
+def test_json_to_markdown_includes_query():
+    data = [{"result": "ok"}]
+    batch = [{"query": "foo"}]
+    md = main.json_to_markdown(data, batch_data=batch)
+    assert "original_query" in md
+    assert json.dumps(batch[0]) in md


### PR DESCRIPTION
## Summary
- include the originating query when converting JSON to Markdown
- document the new behaviour in README
- test that `json_to_markdown` preserves the original query

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688181805b5c833088ce72a0ada89d63