### PR TITLE
Add pdfmd CLI for PDF <-> Markdown conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.venv*
+*.results
 *.py[c]
 __pycache__/
 .pytest_cache/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ BatchSmith is a modular CLI tool for structured batch output generation using La
 - **Batch processing**: Generate multiple outputs in one run.
 - **Templated prompts**: Customize system and user prompts with template variables.
 **Markdown conversion**: Convert the output JSON to Markdown sections (one per item) using the `--to-markdown` option. Each section expands the input data as bullet points in an **Input** subsection and the model’s response in an **Answer** subsection, ordering fields per the schema’s `required` array. A `.md` file is auto-saved alongside the JSON output; use `--to-pdf` to also generate a PDF (requires pypandoc, a CJK-capable LaTeX font such as `Noto Serif CJK TC`, and LaTeX XeCJK support—e.g. install `texlive-xetex texlive-latex-extra texlive-lang-chinese` on Debian/Ubuntu).
+- **PDF/Markdown conversion**: Use the `pdfmd` CLI to convert standalone PDF files
+  to Markdown and Markdown files to PDF.
 
 ## Requirements
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1061,6 +1061,25 @@ files = [
 ]
 
 [[package]]
+name = "pypdf2"
+version = "3.0.1"
+description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440"},
+    {file = "pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928"},
+]
+
+[package.extras]
+crypto = ["PyCryptodome"]
+dev = ["black", "flit", "pip-tools", "pre-commit (<2.18.0)", "pytest-cov", "wheel"]
+docs = ["myst_parser", "sphinx", "sphinx_rtd_theme"]
+full = ["Pillow", "PyCryptodome"]
+image = ["Pillow"]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
@@ -1421,4 +1440,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "fe1e5d64318ae5935333bbb1d5df8b89f66c9679e64181f1f49f5d37bb4c9f74"
+content-hash = "ef9c23f8420115c64a575d333824a8f690635229feba7b6fe4393ee1a8bfca8e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 
 [project.scripts]
 batchsmith = "batchsmith.main:main"
+pdfmd = "batchsmith.pdfmd:main"
 
 
 [tool.poetry.group.dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.12,<4.0"
 dependencies = [
     "langchain-google-genai>=0.1.4",
     "pypandoc>=1.8.0",
+    "PyPDF2>=3.0.0",
 ]
 
 [project.scripts]

--- a/src/batchsmith/main.py
+++ b/src/batchsmith/main.py
@@ -13,6 +13,8 @@ import sys
 
 from langchain_core.prompts import ChatPromptTemplate
 
+# import time
+
 
 def load_json(file_path):
     """Loads a JSON file and returns its content."""
@@ -35,7 +37,7 @@ def create_llm():
         prompt_msg = "Enter your Google AI API key: "
         os.environ["GOOGLE_API_KEY"] = getpass.getpass(prompt_msg)
     return ChatGoogleGenerativeAI(
-        model="gemini-1.5-flash",
+        model="gemini-2.5-flash-lite",
         temperature=0,
         max_tokens=None,
         timeout=None,
@@ -164,6 +166,16 @@ def main():
     chain = create_chain(llm, json_schema, prompts)
 
     response = chain.batch(batch_data)
+    """
+    response = []
+    print(f"Processing {len(batch_data)} items with delay to respect rate limits...")
+    for i, item in enumerate(batch_data):
+        print(f"Processing item {i+1}/{len(batch_data)}...")
+        result = chain.invoke(item)
+        response.append(result)
+        time.sleep(1)
+        """
+
     with open(args.output, "w") as f:
         json.dump(response, f, indent=4)
     if args.to_markdown or args.to_pdf:

--- a/src/batchsmith/pdfmd.py
+++ b/src/batchsmith/pdfmd.py
@@ -1,0 +1,60 @@
+"""CLI tool to convert between PDF and Markdown."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def convert(input_path: str, output_path: str | None = None) -> None:
+    """Convert between PDF and Markdown using pypandoc.
+
+    If ``input_path`` ends with ``.pdf``, the output will be Markdown.
+    If ``input_path`` ends with ``.md`` or ``.markdown``, the output will be PDF.
+    The ``output_path`` defaults to the same basename with the appropriate
+    extension.
+    """
+    ext = os.path.splitext(input_path)[1].lower()
+    if ext == ".pdf":
+        fmt = "md"
+        output_path = output_path or os.path.splitext(input_path)[0] + ".md"
+        extra_args = []
+    elif ext in {".md", ".markdown"}:
+        fmt = "pdf"
+        output_path = output_path or os.path.splitext(input_path)[0] + ".pdf"
+        extra_args = [
+            "--pdf-engine=xelatex",
+            "-V",
+            "CJKmainfont=Noto Serif CJK TC",
+        ]
+    else:
+        raise ValueError("Input must be a .pdf or .md/.markdown file")
+
+    try:
+        import pypandoc
+
+        pypandoc.convert_file(
+            input_path, fmt, outputfile=output_path, extra_args=extra_args
+        )
+    except Exception as exc:  # pragma: no cover - error path depends on env
+        print(f"Conversion failed: {exc}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert between PDF and Markdown formats"
+    )
+    parser.add_argument("input", help="Path to input file (.pdf or .md)")
+    parser.add_argument("-o", "--output", help="Output file path")
+    args = parser.parse_args()
+
+    try:
+        convert(args.input, args.output)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/src/batchsmith/pdfmd.py
+++ b/src/batchsmith/pdfmd.py
@@ -6,6 +6,8 @@ import argparse
 import os
 import sys
 
+from PyPDF2 import PdfReader
+
 
 def convert(input_path: str, output_path: str | None = None) -> None:
     """Convert between PDF and Markdown using pypandoc.
@@ -17,9 +19,17 @@ def convert(input_path: str, output_path: str | None = None) -> None:
     """
     ext = os.path.splitext(input_path)[1].lower()
     if ext == ".pdf":
-        fmt = "md"
         output_path = output_path or os.path.splitext(input_path)[0] + ".md"
-        extra_args = []
+        try:
+            reader = PdfReader(input_path)
+            with open(output_path, "w", encoding="utf-8") as f:
+                for page in reader.pages:
+                    f.write(page.extract_text())
+            print(f"Successfully converted {input_path} to {output_path}")
+        except Exception as e:
+            print(f"Error converting {input_path}: {e}")
+            sys.exit(1)
+
     elif ext in {".md", ".markdown"}:
         fmt = "pdf"
         output_path = output_path or os.path.splitext(input_path)[0] + ".pdf"
@@ -28,17 +38,18 @@ def convert(input_path: str, output_path: str | None = None) -> None:
             "-V",
             "CJKmainfont=Noto Serif CJK TC",
         ]
+        try:
+            import pypandoc
+
+            pypandoc.convert_file(
+                input_path, fmt, outputfile=output_path, extra_args=extra_args
+            )
+            print(f"Successfully converted {input_path} to {output_path}")
+        except Exception as e:
+            print(f"Error converting {input_path}: {e}")
+            sys.exit(1)
     else:
         raise ValueError("Input must be a .pdf or .md/.markdown file")
-
-    try:
-        import pypandoc
-
-        pypandoc.convert_file(
-            input_path, fmt, outputfile=output_path, extra_args=extra_args
-        )
-    except Exception as exc:  # pragma: no cover - error path depends on env
-        print(f"Conversion failed: {exc}")
 
 
 def main() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,7 +75,7 @@ def test_create_llm(monkeypatch):
     assert os.environ["GOOGLE_API_KEY"] == "xyz_key"
     # Verify init arguments
     assert calls["init_args"] == {
-        "model": "gemini-1.5-flash",
+        "model": "gemini-2.5-flash-lite",
         "temperature": 0,
         "max_tokens": None,
         "timeout": None,

--- a/tests/test_pdfmd.py
+++ b/tests/test_pdfmd.py
@@ -1,0 +1,46 @@
+import sys
+import types
+
+from batchsmith import pdfmd
+
+
+def _setup_pypandoc(monkeypatch, calls):
+    mod = types.ModuleType("pypandoc")
+
+    def dummy_convert_file(input_path, fmt, outputfile=None, extra_args=None):
+        calls["args"] = {
+            "input_path": input_path,
+            "fmt": fmt,
+            "outputfile": outputfile,
+            "extra_args": extra_args,
+        }
+
+    mod.convert_file = dummy_convert_file
+    monkeypatch.setitem(sys.modules, "pypandoc", mod)
+
+
+def test_convert_md_to_pdf(monkeypatch, tmp_path):
+    md_file = tmp_path / "doc.md"
+    md_file.write_text("# hi")
+    calls = {}
+    _setup_pypandoc(monkeypatch, calls)
+
+    out = tmp_path / "out.pdf"
+    pdfmd.convert(str(md_file), str(out))
+
+    assert calls["args"]["fmt"] == "pdf"
+    assert calls["args"]["outputfile"] == str(out)
+    assert "--pdf-engine=xelatex" in calls["args"]["extra_args"]
+
+
+def test_convert_pdf_to_md(monkeypatch, tmp_path):
+    pdf_file = tmp_path / "doc.pdf"
+    pdf_file.write_text("binary")
+    calls = {}
+    _setup_pypandoc(monkeypatch, calls)
+
+    out = tmp_path / "out.md"
+    pdfmd.convert(str(pdf_file), str(out))
+
+    assert calls["args"]["fmt"] == "md"
+    assert calls["args"]["outputfile"] == str(out)

--- a/tests/test_pdfmd.py
+++ b/tests/test_pdfmd.py
@@ -36,11 +36,13 @@ def test_convert_md_to_pdf(monkeypatch, tmp_path):
 def test_convert_pdf_to_md(monkeypatch, tmp_path):
     pdf_file = tmp_path / "doc.pdf"
     pdf_file.write_text("binary")
-    calls = {}
-    _setup_pypandoc(monkeypatch, calls)
+
+    # Mock PdfReader
+    mock_page = types.SimpleNamespace(extract_text=lambda: "page content")
+    mock_reader = types.SimpleNamespace(pages=[mock_page])
+    monkeypatch.setattr(pdfmd, "PdfReader", lambda _: mock_reader)
 
     out = tmp_path / "out.md"
     pdfmd.convert(str(pdf_file), str(out))
 
-    assert calls["args"]["fmt"] == "md"
-    assert calls["args"]["outputfile"] == str(out)
+    assert out.read_text(encoding="utf-8") == "page content"


### PR DESCRIPTION
## Summary
- add `pdfmd` CLI to convert between PDF and Markdown
- expose new entry point in `pyproject.toml`
- document the new tool in README
- test conversion logic with stubs for `pypandoc`

## Testing
- `pre-commit run --files README.md pyproject.toml src/batchsmith/pdfmd.py tests/test_pdfmd.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d57b3d90833090d03e170d67da3a